### PR TITLE
Fix enabled-on-self-origin-by-permissions-policy.https.sub.html

### DIFF
--- a/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -9,6 +9,7 @@
 <body></body>
 <script type="module">
     import { makeGetOptions } from "./support/helper.js";
+    import { makeCreateOptions } from "./support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
     const get_same_origin_src =
         "/permissions-policy/resources/digital-credentials-get.html";


### PR DESCRIPTION
The code didn't import `makeCreateOptions` and hence it caused `"ReferenceError: makeCreateOptions is not defined"`